### PR TITLE
Fields double wrap fix

### DIFF
--- a/target_airtable/sinks.py
+++ b/target_airtable/sinks.py
@@ -20,9 +20,7 @@ class AirtableSink(BatchSink):
 
         def preprocess_records(x):
             # Wrap every record in a JSON object under the fields
-            return {
-                "fields": x
-            }
+            return x
 
         records = [preprocess_records(x) for x in context["records"]]
         # Get the records_url (we have a default, but that may change)
@@ -30,7 +28,7 @@ class AirtableSink(BatchSink):
         # Get the base id
         base_id = self.config.get("base_id")
         # Get the table name (URL encoded)
-        table_name = urllib.parse.quote(self.stream_name)
+        table_name = self.config.get("table_name",urllib.parse.quote(self.stream_name))
         token = self.config.get("token")
         endpoint = f"{records_url}/{base_id}/{table_name}"
 

--- a/target_airtable/sinks.py
+++ b/target_airtable/sinks.py
@@ -45,6 +45,7 @@ class AirtableSink(BatchSink):
         if not r.ok:
             # If request fails, log error message
             self.logger.error(r.text)
+            raise Exception(r.text)
 
         # Clean up records
         context["records"] = []

--- a/target_airtable/sinks.py
+++ b/target_airtable/sinks.py
@@ -20,7 +20,12 @@ class AirtableSink(BatchSink):
 
         def preprocess_records(x):
             # Wrap every record in a JSON object under the fields
-            return x
+            if not "fields" in x:
+                return {
+                    "fields": x
+                }
+            else:
+                return x
 
         records = [preprocess_records(x) for x in context["records"]]
         # Get the records_url (we have a default, but that may change)

--- a/target_airtable/target.py
+++ b/target_airtable/target.py
@@ -22,3 +22,6 @@ class TargetAirtable(Target):
         th.Property("records_url", th.StringType)
     ).to_dict()
     default_sink_class = AirtableSink
+
+if __name__ == '__main__':
+    TargetAirtable.cli()


### PR DESCRIPTION
preprocess_records function was double wrapping the fields into the fields. Maybe at the time of writing payload was different 

Also, API needs valid table name made configurable through config or stream name(as it was already)